### PR TITLE
fix end of year bug

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "goilluminate/elm-fancy-daterangepicker",
     "summary": "A fancy daterangepicker in elm.",
     "license": "BSD-3-Clause",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "exposed-modules": [
         "DateRangePicker",
         "DatePicker",

--- a/src/DateRangePicker/Common/Internal.elm
+++ b/src/DateRangePicker/Common/Internal.elm
@@ -115,7 +115,7 @@ prepareYear date =
             fromCalendarDate yr Jan 1
 
         end =
-            fromCalendarDate yr Dec 31
+            fromCalendarDate (yr + 1) Jan 1
 
         dates =
             Date.range Date.Day 1 start end


### PR DESCRIPTION
Date.range goes from start up to end, not including end.

So when I was doing
`Date.range Data.Day 1 (fromCalendarDate year Jan 1) (fromCalendarDate year Dec 31)`
it was not including Dec 31 in the year, it was stopping at Dec 30