### PR TITLE
Update the visible calendar range when manually setting the selection

### DIFF
--- a/src/DateRangePicker.elm
+++ b/src/DateRangePicker.elm
@@ -852,10 +852,14 @@ setSelection selection (DatePicker model) =
 
                 _ ->
                     selection
-    in
-    DatePicker
-        (withUpdatedSelection newSelection model)
 
+        updated =
+            withUpdatedSelection newSelection model
+
+        withUpdatedViewRange =
+            { updated | visibleCalendarRange = getVisibleRangeFromSelection selection model.calendarType (DatePicker updated) }
+    in
+    DatePicker withUpdatedViewRange
 
 {-| A helper function to display the selection in the same way that the datepicker does
 -}


### PR DESCRIPTION
This is to fix a bug where you programatically set the range to be years in the past but when you open it the current year is still shown

Before:
![date-open-wrong-year-before-fix](https://github.com/GoIlluminate/elm-fancy-daterangepicker/assets/1985939/3668ae05-a9da-4b0d-ab64-8ea284d751d0)

After:
![date-open-wrong-year-after-fix](https://github.com/GoIlluminate/elm-fancy-daterangepicker/assets/1985939/5668ca71-6a15-45b4-8008-a5c020cbc45d)
